### PR TITLE
Add missing install step

### DIFF
--- a/src/module/Makefile
+++ b/src/module/Makefile
@@ -1,6 +1,8 @@
 #VER=2.6.29.2
 KVER=$(shell uname -r)
 KSRC=/lib/modules/$(KVER)/build
+MODULE_INSTALL_PATH=/lib/modules/$(KVER)/iCubDrivers/cfw002/LinuxDriver
+MODULE_TARGET=cfw002.ko
 
 obj-m := cfw002.o
 
@@ -16,3 +18,7 @@ driver:
 clean: 
 	$(MAKE) -C $(KSRC) M=$(PWD) clean
 	@rm -f Module.symvers
+
+install: $(MODULE_TARGET)
+	mkdir -p $(MODULE_INSTALL_PATH)
+	cp $(MODULE_TARGET) $(MODULE_INSTALL_PATH)/


### PR DESCRIPTION
The `install` step from `module` was removed in 18e993ab05430705864b4c7c53cbbd6fa8a2217c, but this now causes an issue since it is still called in the main Makefile.
I simply re-added the install step in the `module` Makefile.
cf Issue https://github.com/robotology/cfw002/issues/3